### PR TITLE
Set DYNO env var based on process-type

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -30,6 +30,10 @@ var cmdRun = cli.Command{
 			Name:  "stack",
 			Usage: "The name of the packs stack image to use",
 		},
+		cli.StringFlag{
+			Name:  "process-type",
+			Usage: "The process type of the container",
+		},
 		cli.IntFlag{
 			Name:  "port",
 			Usage: "The local port to use",
@@ -69,6 +73,11 @@ var cmdRun = cli.Command{
 			name := parts[0]
 			value := parts[1]
 			envVars[name] = value
+		}
+
+		processType := c.Flags.String("process-type")
+		if processType != "" {
+			envVars["DYNO"] = fmt.Sprintf("%s.1", processType)
 		}
 
 		port := c.Flags.Int("port")


### PR DESCRIPTION
Also adds `process-type` as an env var. See also https://github.com/buildpack/packs/pull/11