### PR TITLE
Add a warning if autocrlf is enabled on Windows

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"runtime"
+	"os/exec"
 
 	"github.com/docker/docker/api/types"
 	dockerClient "github.com/docker/docker/client"
@@ -100,6 +102,24 @@ var cmdBuild = cli.Command{
 			err := ui.Loading("Downloading Build Image", engine.NewImage().Pull(buildStack))
 			if err != nil {
 				return cli.ExitStatusUnknownError, err
+			}
+		}
+
+		if runtime.GOOS == "windows" {
+			cmd := exec.Command("git", "config", "core.autocrlf")
+			stdout, err := cmd.Output()
+			if err == nil {
+				autocrlf := strings.TrimSpace(string(stdout))
+				if autocrlf == "true" {
+					fmt.Println(`WARNING: Git core.autcrlf is enabled, which may cause unexpected errors in Bash
+         scripts. It is recommended that you disable this feature by running:
+
+           C:\> git config --global core.autocrlf false
+
+         The rewrite the Git index to pick up all the new line endings by
+         running 'git reset' on your repo.
+`)
+				}
 			}
 		}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -11,8 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"runtime"
-	"os/exec"
 
 	"github.com/docker/docker/api/types"
 	dockerClient "github.com/docker/docker/client"
@@ -22,6 +20,7 @@ import (
 	"github.com/heroku/tatara/fs"
 	"github.com/heroku/tatara/heroku"
 	"github.com/heroku/tatara/ui"
+	"github.com/heroku/tatara/util"
 	"github.com/buildpack/forge"
 	"github.com/buildpack/forge/app"
 	"github.com/buildpack/forge/engine"
@@ -105,23 +104,7 @@ var cmdBuild = cli.Command{
 			}
 		}
 
-		if runtime.GOOS == "windows" {
-			cmd := exec.Command("git", "config", "core.autocrlf")
-			stdout, err := cmd.Output()
-			if err == nil {
-				autocrlf := strings.TrimSpace(string(stdout))
-				if autocrlf == "true" {
-					fmt.Println(`WARNING: Git core.autcrlf is enabled, which may cause unexpected errors in Bash
-         scripts. It is recommended that you disable this feature by running:
-
-           C:\> git config --global core.autocrlf false
-
-         The rewrite the Git index to pick up all the new line endings by
-         running 'git reset' on your repo.
-`)
-				}
-			}
-		}
+		util.WarnIfGitAutoCrlfEnabled()
 
 		herokuConfig, err := heroku.ReadConfig(appDir)
 		if err == nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/heroku/tatara/fs"
 	"github.com/heroku/tatara/heroku"
 	"github.com/heroku/tatara/ui"
+	"github.com/heroku/tatara/util"
 	"github.com/buildpack/forge"
 	"github.com/buildpack/forge/engine"
 	"github.com/buildpack/forge/engine/docker"
@@ -117,6 +118,9 @@ var cmdRun = cli.Command{
 				return cli.ExitStatusUnknownError, err
 			}
 		}
+
+		util.WarnIfGitAutoCrlfEnabled()
+
 		curDir, err := os.Getwd()
 		if err != nil {
 			return cli.ExitStatusUnknownError, err

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+  "runtime"
+  "os/exec"
+	"strings"
+	"fmt"
+)
+
+func WarnIfGitAutoCrlfEnabled() {
+  if runtime.GOOS == "windows" {
+    cmd := exec.Command("git", "config", "core.autocrlf")
+    stdout, err := cmd.Output()
+    if err == nil {
+      autocrlf := strings.TrimSpace(string(stdout))
+      if autocrlf == "true" {
+        fmt.Println(`WARNING: Git core.autcrlf is enabled
+This option may cause unexpected errors in Bash scripts.
+It is recommended that you disable this feature by running:
+
+    C:\> git config --global core.autocrlf false
+
+Then rewrite the Git index to pick up all the new line endings
+by running 'git reset' on your repo.`)
+      }
+    }
+  }
+}


### PR DESCRIPTION
When `git clone` is run on repos that contain files like [`mvnw`](https://github.com/heroku/java-getting-started/blob/master/mvnw) or [`bin/bundle`](https://github.com/heroku/ruby-getting-started/blob/master/bin/bundle) and Git's `core.autocrlf` is set to `true`, then Git will replace LF line-endings with CRLF.

When these files are copied into a Docker image, and executed with Bash, we get errors like:

```
/bin/ruby^M: bad interpreter: No such file or directory
```

The `^M` is the carriage return (CR).