### PR TITLE
port

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,15 +8,15 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/buildpack/forge"
+	"github.com/buildpack/forge/engine"
+	"github.com/buildpack/forge/engine/docker"
 	"github.com/fatih/color"
 	"github.com/heroku/tatara/cli"
 	"github.com/heroku/tatara/fs"
 	"github.com/heroku/tatara/heroku"
 	"github.com/heroku/tatara/ui"
 	"github.com/heroku/tatara/util"
-	"github.com/buildpack/forge"
-	"github.com/buildpack/forge/engine"
-	"github.com/buildpack/forge/engine/docker"
 )
 
 const (
@@ -87,10 +87,10 @@ var cmdRun = cli.Command{
 		}
 
 		port := c.Flags.Int("port")
-		if port == 0 {
-			port = 5000
-		} else {
+		if port != 0 {
 			envVars["PORT"] = strconv.FormatUint(uint64(port), 10)
+		} else if !shell && (processType == "" || processType == "web") {
+			port = 5000
 		}
 
 		sysFS := &fs.FS{}
@@ -138,15 +138,21 @@ var cmdRun = cli.Command{
 		}
 
 		netConfig := &forge.NetworkConfig{
-			HostIP:        "127.0.0.1",
-			HostPort:      strconv.FormatUint(uint64(port), 10),
-			ContainerPort: strconv.FormatUint(uint64(port), 10),
+			HostIP: "127.0.0.1",
+		}
+		if port > 0 {
+			netConfig.HostPort = strconv.FormatUint(uint64(port), 10)
+			netConfig.ContainerPort = strconv.FormatUint(uint64(port), 10)
 		}
 
 		runner := forge.NewRunner(engine)
 		runner.Logs = color.Output
 
-		fmt.Println(fmt.Sprintf("Running %s on port %d...", appName, port))
+		if port > 0 {
+			fmt.Println(fmt.Sprintf("Running %s on port %d...", appName, port))
+		} else {
+			fmt.Println(fmt.Sprintf("Running %s...", appName))
+		}
 		_, err = runner.Run(&forge.RunConfig{
 			Droplet:       slug,
 			Stack:         stack,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -89,6 +89,8 @@ var cmdRun = cli.Command{
 		port := c.Flags.Int("port")
 		if port == 0 {
 			port = 5000
+		} else {
+			envVars["PORT"] = strconv.FormatUint(uint64(port), 10)
 		}
 
 		sysFS := &fs.FS{}


### PR DESCRIPTION
Set PORT env var for the dyno to the port set via CLI
    
By default the heroku app launcher defaults to 5000 and doesn't change if the container port is set.

In addition, now the container will only try to bind to the host port if we're on the web process type or if port is passed in via the CLI.