### PR TITLE
Remove app command when exporting

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -106,7 +106,6 @@ var cmdExport = cli.Command{
 			OutputDir:  "/",
 			AppConfig: &forge.AppConfig{
 				Name:    appName,
-				Command: "/packs/launcher",
 			},
 		})
 


### PR DESCRIPTION
Fixes #16 

However, this results in an empty command displayed on Heroku:

```
$ heroku ps
=== web (Free): '' (1)
web.1: up 2018/07/24 09:28:09 -0500 (~ 1m ago)
```

And:

```
2018-07-24T14:27:51.164715+00:00 heroku[web.1]: Starting process with command `''`
```